### PR TITLE
[Bug] fix logsumexp parameter

### DIFF
--- a/platform/ascend/2_6/应用实践/自然语言处理/LSTM+CRF序列标注.ipynb
+++ b/platform/ascend/2_6/应用实践/自然语言处理/LSTM+CRF序列标注.ipynb
@@ -212,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "d9a0ef6a-1c3a-400e-9053-e0659e8f9e7e",
    "metadata": {
     "tags": []
@@ -246,7 +246,7 @@
     "\n",
     "        # 对score_i做log_sum_exp运算，用于下一个Token的score计算\n",
     "        # shape: (batch_size, num_tags)\n",
-    "        next_score = ops.logsumexp(next_score, axis=1)\n",
+    "        next_score = ops.logsumexp(next_score, dim=1)\n",
     "\n",
     "        # 当mask == 1时，score才会变化\n",
     "        # shape: (batch_size, num_tags)\n",
@@ -257,7 +257,7 @@
     "    score += end_trans\n",
     "    # 对所有可能的路径得分求log_sum_exp\n",
     "    # shape: (batch_size,)\n",
-    "    return ops.logsumexp(score, axis=1)"
+    "    return ops.logsumexp(score, dim=1)"
    ]
   },
   {


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!  Here are a few tips to guide you:

1. If this is your first time, please read our [contributor guidelines](https://github.com/opensourcedot/xihe-cases/blob/main/CONTRIBUTING.md)
2. Ensure you have tested your changes on the [xihe.mindspore.cn](https://xihe.mindspore.cn)
-->

## PR Type
> Please uncomment only one of the following lines, remove the leading spaces, and leave the other options commented out:
>
> /kind ascend-case


## Description of Changes
<!--
Please describe the reasoning behind your changes. What problem do they solve, or how do they improve the project? 
-->
Fix bug `ops.logsumexp(next_score, axis=1)` in mindspore2.6.0, update `axis` to `dim`


## Related Issues
<!--
If this PR is related to any existing issues or PRs, please link them here using GitHub’s syntax. 
For example: "Fixes #123", "Part of #456", or "Relates to #789".
-->
Fixes #46 
